### PR TITLE
Use basestring instead of str for type checking

### DIFF
--- a/awssl/and_choice_rule.py
+++ b/awssl/and_choice_rule.py
@@ -65,7 +65,7 @@ class AndChoiceRule(object):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = AndChoiceRule()

--- a/awssl/catcher.py
+++ b/awssl/catcher.py
@@ -52,7 +52,7 @@ class Catcher(object):
 		if len(ErrorNameList) == 0:
 			raise Exception("ErrorNameList must be a non-empty list for a Catcher")
 		for o in ErrorNameList:
-			if not isinstance(o, str):
+			if not isinstance(o, basestring):
 				raise Exception("ErrorNameList must only contain strings")
 		self._error_name_list = ErrorNameList
 
@@ -81,7 +81,7 @@ class Catcher(object):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the instance is incorrectly defined.
-		
+
 		"""
 		if not self.get_next_state():
 			raise Exception("Catcher must have a NextState")
@@ -93,7 +93,7 @@ class Catcher(object):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		return {
 			"ErrorEquals" : self.get_error_name_list(),
@@ -114,7 +114,7 @@ class Catcher(object):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		cloned_error_name_list = None

--- a/awssl/choice_rule.py
+++ b/awssl/choice_rule.py
@@ -55,7 +55,7 @@ class ChoiceRule(object):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = ChoiceRule(Comparison=self.get_comparison().clone())

--- a/awssl/choice_state.py
+++ b/awssl/choice_state.py
@@ -7,7 +7,7 @@ from .or_choice_rule import OrChoiceRule
 
 class Choice(StateInputOutput):
 	"""
-	Models the Choice state, which allows multiple Choice Rules to be tested, and to redirect to the 
+	Models the Choice state, which allows multiple Choice Rules to be tested, and to redirect to the
 	state specified by the first Choice Rule that passes.
 
 	If no Choice Rules pass, then the State Machine redirects to the state specified as Default (if one)
@@ -54,7 +54,7 @@ class Choice(StateInputOutput):
 			choices.append(o.to_json())
 
 		j = super(Choice, self).to_json()
-		j["Choices"] = choices 
+		j["Choices"] = choices
 		if self.get_default():
 			j["Default"] = self.get_default().get_name()
 		return j
@@ -81,7 +81,7 @@ class Choice(StateInputOutput):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Choice(
@@ -92,6 +92,6 @@ class Choice(StateInputOutput):
 			ChoiceList=[ c.clone(NameFormatString) for c in self.get_choice_list() ])
 
 		if self.get_default():
-			c.set_default(Default=self.get_default().clone(NameFormatString))	
+			c.set_default(Default=self.get_default().clone(NameFormatString))
 
 		return c

--- a/awssl/comparison.py
+++ b/awssl/comparison.py
@@ -1,6 +1,6 @@
 class Comparison(object):
 	"""
-	Defines the available set of Comparisons which returns True or False 
+	Defines the available set of Comparisons which returns True or False
 	"""
 
 	def __init__(self, Variable=None, Comparator=None, Value=None):
@@ -22,10 +22,10 @@ class Comparison(object):
 
 	def _get_value_types(self):
 		return {
-			"String" : (str),
+			"String" : (basestring),
 			"Numeric": (int, float),
 			"Boolean": (bool),
-			"Timestamp": (str)
+			"Timestamp": (basestring)
 		}
 
 	def _validate_value_against_comparator(self, value):
@@ -36,7 +36,7 @@ class Comparison(object):
 		return self._variable
 
 	def set_variable(self, Variable=None):
-		if (not Variable) or not isinstance(Variable, str):
+		if (not Variable) or not isinstance(Variable, basestring):
 			raise Exception("ChoiceRule must have a Variable, which must be a string")
 		self._variable = Variable
 
@@ -44,11 +44,11 @@ class Comparison(object):
 		return self._comparator
 
 	def set_comparator(self, Comparator=None):
-		if (not Comparator) or not isinstance(Comparator, str):
+		if (not Comparator) or not isinstance(Comparator, basestring):
 			raise Exception("ChoiceRule must have a Comparator, which must be a string")
 		self._comparator = None
 		self._comparator_type = None
-		for key in self._get_comparators().keys():			
+		for key in self._get_comparators().keys():
 			if Comparator in self._get_comparators()[key]:
 				self._comparator_type = key
 				break

--- a/awssl/ext/branch_retry_parallel.py
+++ b/awssl/ext/branch_retry_parallel.py
@@ -1,4 +1,4 @@
-from ..pass_state import Pass 
+from ..pass_state import Pass
 from ..parallel_state import Parallel
 from .parallel_with_finally import ParallelWithFinally
 from ..state_base import StateBase
@@ -35,17 +35,17 @@ class BranchRetryParallel(ParallelWithFinally):
 	:type: CatcherList: list of ``Catcher``
 	:param FinallyState: [Optional] First state of the finally branch to be invoked
 	:type: FinallyState: Derived from ``StateBase``
-	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 	:type: BranchList: list of ``StateBase``
 	:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that can be retried for each branch
 	:type: BranchRetryList: list of ``StateBase``
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None,
 					ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None, BranchList=None, BranchRetryList=None):
-		super(BranchRetryParallel, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(BranchRetryParallel, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, FinallyState=FinallyState)
 		"""
 		Initializer for the ``BranchRetryParallel`` state.
@@ -75,7 +75,7 @@ class BranchRetryParallel(ParallelWithFinally):
 		:type: CatcherList: list of ``Catcher``
 		:param FinallyState: [Optional] First state of the finally branch to be invoked
 		:type: FinallyState: Derived from ``StateBase``
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 		:type: BranchList: list of ``StateBase``
 		:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that can be retried for each branch
 		:type: BranchRetryList: list of ``StateBase``
@@ -89,7 +89,7 @@ class BranchRetryParallel(ParallelWithFinally):
 	def _get_underlying_state_no_retry_catch(self, state_name):
 		branch_list = []
 		if self.get_branch_retry_list() and len(self.get_branch_retry_list()) > 0:
-			# Wrap each branch in its own retrying Parallel		
+			# Wrap each branch in its own retrying Parallel
 			for b in self.get_branch_list():
 				final_state = Pass(
 					Name="{}-Finalizer-{}".format(self.get_name(), b.get_name()),
@@ -129,8 +129,8 @@ class BranchRetryParallel(ParallelWithFinally):
 
 		At least one branch is required for the state to be valid.
 
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
-		:type: BranchList: list of ``StateBase``		
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
+		:type: BranchList: list of ``StateBase``
 		"""
 		if not BranchList:
 			self._brp_branch_list = None
@@ -149,7 +149,7 @@ class BranchRetryParallel(ParallelWithFinally):
 
 	def get_branch_retry_list(self):
 		"""
-		Returns the list of ``Retrier`` instances that will be applied to each branch separately, allowing failure 
+		Returns the list of ``Retrier`` instances that will be applied to each branch separately, allowing failure
 		in one branch to be retried without having to re-execute all the branches of the ``Parallel``.
 
 		:returns: ``list`` of ``Retrier`` instances
@@ -195,7 +195,7 @@ class BranchRetryParallel(ParallelWithFinally):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = BranchRetryParallel(
@@ -213,7 +213,7 @@ class BranchRetryParallel(ParallelWithFinally):
 			c.set_branch_retry_list(BranchRetryList=[ r.clone() for r in self.get_branch_retry_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		if self.get_finally_state():
 			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))

--- a/awssl/ext/for_state.py
+++ b/awssl/ext/for_state.py
@@ -1,5 +1,5 @@
-from ..pass_state import Pass 
-from ..task_state import Task 
+from ..pass_state import Pass
+from ..task_state import Task
 from ..parallel_state import Parallel
 from ..state_base import StateBase
 from ..retrier import Retrier
@@ -13,7 +13,7 @@ _FINALIZER = "ForFinalizer"
 _FINALIZER_PARALLEL_ITERATION = "ForFinalizerParallelIterations"
 _LIMITED_PARALLEL_CONSOLIDATOR = "LimitedParallelConsolidator"
 
-def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None, 
+def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None,
 				ForFinalizer=None, ForFinalizerParallelIterations=None,
 				LimitedParallelConsolidator=None):
 	"""
@@ -22,7 +22,7 @@ def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None,
 	The functions are available in the github repo both as individual lambdas or combined in a CloudFormation script for easy deployment.
 
 	All the Arns must be specified or this function will generate an Exception.
-	
+
 	:param ForInitializer: The Arn of the ForInitializer Lambda function, used by the ``For`` state
 	:type ForInitializer: str
 	:param ForExtractor: The Arn of the ForExtractor Lambda function, used by the ``For`` state
@@ -40,12 +40,12 @@ def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None,
 	def apply_arg(val, val_name):
 		if not val:
 			raise Exception("set_ext_arns: {} must not be None".format(val_name))
-		if not isinstance(val, str):
+		if not isinstance(val, basestring):
 			raise Exception("set_ext_arns: {} must be a str".format(val_name))
 		_ext_arns[val_name] = val
 
-	for v, n in [(ForInitializer, _INITIALIZER), (ForExtractor, _EXTRACTOR), 
-				(ForConsolidator, _CONSOLIDATOR), (ForFinalizer, _FINALIZER), 
+	for v, n in [(ForInitializer, _INITIALIZER), (ForExtractor, _EXTRACTOR),
+				(ForConsolidator, _CONSOLIDATOR), (ForFinalizer, _FINALIZER),
 				(ForFinalizerParallelIterations, _FINALIZER_PARALLEL_ITERATION),
 				(LimitedParallelConsolidator, _LIMITED_PARALLEL_CONSOLIDATOR) ]:
 		apply_arg(v, n)
@@ -122,8 +122,8 @@ class For(Parallel):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
-					ResultPath="$", RetryList=None, CatcherList=None, BranchState=None, BranchRetryList=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None,
+					ResultPath="$", RetryList=None, CatcherList=None, BranchState=None, BranchRetryList=None,
 					From=0, To=0, Step=1, IteratorPath="$.iteration", ParallelIteration=False):
 		"""
 		Initializer for the ``For`` class
@@ -161,12 +161,12 @@ class For(Parallel):
 		:param ParallelIteration: [Optional] Whether the ``For`` branches can be run concurrently or must be executed sequentially.  Default is sequential.
 		:type ParallelIteration: bool
 
-		"""		
-		super(For, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		"""
+		super(For, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, BranchList=None)
 		self._branch_state = None
-		self._from = 0 
+		self._from = 0
 		self._to = 0
 		self._step = 1
 		self._iterator_path = None
@@ -288,8 +288,8 @@ class For(Parallel):
 		"""
 		Sets the starting value for the ``For`` loop.  Must be an integer or float.  Default value is zero.
 
-		:param From: [Required] The starting value of the iteration.  
-		:type From: int or float		
+		:param From: [Required] The starting value of the iteration.
+		:type From: int or float
 		"""
 		if not isinstance(From, (int, float)):
 			raise Exception("From must be either an int or a float (step '{}')".format(self.get_name()))
@@ -307,8 +307,8 @@ class For(Parallel):
 		"""
 		Sets the ending value for the ``For`` loop.  Must be an integer or float.  Default value is zero.
 
-		:param To: [Required] The ending value of the iteration.  
-		:type To: int or float		
+		:param To: [Required] The ending value of the iteration.
+		:type To: int or float
 		"""
 		if not isinstance(To, (int, float)):
 			raise Exception("To must be either an int or a float (step '{}')".format(self.get_name()))
@@ -326,8 +326,8 @@ class For(Parallel):
 		"""
 		Sets the increment value for the ``For`` loop.  Must be an integer or float.  Default value is 1.
 
-		:param Step: [Required] The increment value of the iteration.  
-		:type Step: int or float		
+		:param Step: [Required] The increment value of the iteration.
+		:type Step: int or float
 		"""
 		if not isinstance(Step, (int, float)):
 			raise Exception("Step must be either an int or a float (step '{}')".format(self.get_name()))
@@ -357,7 +357,7 @@ class For(Parallel):
 
 	def get_branch_retry_list(self):
 		"""
-		Returns the list of ``Retrier`` instances that will be applied separately to each ``For`` branch iteration, allowing failure 
+		Returns the list of ``Retrier`` instances that will be applied separately to each ``For`` branch iteration, allowing failure
 		in one branch iteration during the ``For`` loop to be retried without having to re-execute all the branches of the ``For``.
 
 		:returns: ``list`` of ``Retrier`` instances
@@ -416,7 +416,7 @@ class For(Parallel):
 		"""
 		Specifies whether the execution of the ``For`` loop can be performed concurrently, or must be sequential.  Default is sequential.
 
-		:param ParallelIteration: [Optional] Whether the ``For`` branches can be run concurrently or must be executed sequentially.  
+		:param ParallelIteration: [Optional] Whether the ``For`` branches can be run concurrently or must be executed sequentially.
 		:type ParallelIteration: bool
 		"""
 		self._parallel_iteration = ParallelIteration
@@ -426,7 +426,7 @@ class For(Parallel):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		self._build_for_loop()
 		super(For, self).validate()
@@ -436,7 +436,7 @@ class For(Parallel):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		self._build_for_loop()
 		return super(For, self).to_json()
@@ -455,7 +455,7 @@ class For(Parallel):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = For(
@@ -481,6 +481,6 @@ class For(Parallel):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		return c

--- a/awssl/ext/limited_parallel_state.py
+++ b/awssl/ext/limited_parallel_state.py
@@ -1,5 +1,5 @@
-from ..pass_state import Pass 
-from ..task_state import Task 
+from ..pass_state import Pass
+from ..task_state import Task
 from ..parallel_state import Parallel
 from ..retrier import Retrier
 from ..state_base import StateBase
@@ -43,7 +43,7 @@ class LimitedParallel(StateRetryCatch):
 	:type: RetryList: list of ``Retrier``
 	:param CatcherList: [Optional] ``list`` of ``Catcher`` instances corresponding to error states that can be caught and handled by further states being executed in the ``StateMachine``.
 	:type: CatcherList: list of ``Catcher``
-	:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently 
+	:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently
 	:type: BranchState: ``StateBase``
 	:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that cause the ``For`` loop iteration to be retried.  This will occur until the number of retries has been exhausted for this iteration, afterwhich state level ``Retrier`` will be triggered if specified
 	:type BranchRetryList: list of ``Retrier``
@@ -56,8 +56,8 @@ class LimitedParallel(StateRetryCatch):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
-					ResultPath="$", RetryList=None, CatcherList=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None,
+					ResultPath="$", RetryList=None, CatcherList=None,
 					BranchState=None, BranchRetryList=None,
 					Iterations=0, MaxConcurrency=1, IteratorPath="$.iteration"):
 		"""
@@ -81,7 +81,7 @@ class LimitedParallel(StateRetryCatch):
 		:type: RetryList: list of ``Retrier``
 		:param CatcherList: [Optional] ``list`` of ``Catcher`` instances corresponding to error states that can be caught and handled by further states being executed in the ``StateMachine``.
 		:type: CatcherList: list of ``Catcher``
-		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently 
+		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently
 		:type: BranchState: ``StateBase``
 		:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that cause the ``For`` loop iteration to be retried.  This will occur until the number of retries has been exhausted for this iteration, afterwhich state level ``Retrier`` will be triggered if specified
 		:type BranchRetryList: list of ``Retrier``
@@ -93,8 +93,8 @@ class LimitedParallel(StateRetryCatch):
 		:type: IteratorPath: str
 
 		"""
-		super(LimitedParallel, self).__init__(Name=Name, Type="Ext", Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(LimitedParallel, self).__init__(Name=Name, Type="Ext", Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList)
 		self._branch_state = None
 		self._max_concurrent = 1
@@ -116,23 +116,23 @@ class LimitedParallel(StateRetryCatch):
 
 			for_state = For(Name="{}-For-{}".format(state_name, cycle),
 							EndState=True,
-							From=iteration_offset, 
-							To=iteration_offset+iterations, 
-							Step=1, 
+							From=iteration_offset,
+							To=iteration_offset+iterations,
+							Step=1,
 							BranchState=branch_state,
 							BranchRetryList=branch_retry_list,
-							IteratorPath=iterator_path, 
+							IteratorPath=iterator_path,
 							ParallelIteration=True)
 
-			inputs = Pass(Name="{}-Pass-Inputs-{}".format(state_name, cycle), 
+			inputs = Pass(Name="{}-Pass-Inputs-{}".format(state_name, cycle),
 				OutputPath="$.[0]",
 				EndState=True)
 
-			existing_results = Pass(Name="{}-Pass-Results-{}".format(state_name, cycle), 
+			existing_results = Pass(Name="{}-Pass-Results-{}".format(state_name, cycle),
 				OutputPath="$.[1]",
 				EndState=True)
 
-			loop_inputs = Pass(Name="{}-Loop-Inputs-{}".format(state_name, cycle), 
+			loop_inputs = Pass(Name="{}-Loop-Inputs-{}".format(state_name, cycle),
 				OutputPath="$.[0]",
 				EndState=False,
 				NextState=for_state)
@@ -143,7 +143,7 @@ class LimitedParallel(StateRetryCatch):
 			if cycle == 0:
 				initializer_arn = get_ext_arn(_INITIALIZER)
 
-			cycle_state = Parallel(Name="{}-Parallel-{}".format(state_name, cycle), 
+			cycle_state = Parallel(Name="{}-Parallel-{}".format(state_name, cycle),
 									EndState=True,
 									BranchList=branch_list)
 
@@ -169,7 +169,7 @@ class LimitedParallel(StateRetryCatch):
 				cycle_iterations = self.get_max_concurrency()
 			remaining_iterations = remaining_iterations - cycle_iterations
 
-			cycle_initializer, prior_state = create_states_for_cycle(cycle, cycle_iterations, cycle * self.get_max_concurrency(), 
+			cycle_initializer, prior_state = create_states_for_cycle(cycle, cycle_iterations, cycle * self.get_max_concurrency(),
 												self.get_branch_state(), self.get_branch_retry_list(),
 												self.get_iterator_path(), prior_state, self.get_name())
 
@@ -225,7 +225,7 @@ class LimitedParallel(StateRetryCatch):
 		"""
 		Set the initial state for the branch processing
 
-		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently 
+		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently
 		:type: BranchState: ``StateBase``
 		"""
 		if BranchState and not isinstance(BranchState, StateBase):
@@ -234,7 +234,7 @@ class LimitedParallel(StateRetryCatch):
 
 	def get_branch_retry_list(self):
 		"""
-		Returns the list of ``Retrier`` instances that will be applied separately to each branch execution, allowing failure 
+		Returns the list of ``Retrier`` instances that will be applied separately to each branch execution, allowing failure
 		in one branch iteration during the ``LimitedParallel`` execution to be retried.
 
 		:returns: ``list`` of ``Retrier`` instances
@@ -305,7 +305,7 @@ class LimitedParallel(StateRetryCatch):
 		"""
 		if not IteratorPath:
 			raise Exception("IteratorPath must not be None or empty str (step '{}')".format(self.get_name()))
-		if not isinstance(IteratorPath, str):
+		if not isinstance(IteratorPath, basestring):
 			raise Exception("IteratorPath must be a str (step '{}')".format(self.get_name()))
 		self._iterator_path = IteratorPath
 
@@ -337,10 +337,10 @@ class LimitedParallel(StateRetryCatch):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		# Ensure basic inputs are ok
-		super(LimitedParallel, self).validate() 
+		super(LimitedParallel, self).validate()
 
 		# Ensure constructed LimitedParallel is ok
 		self._lp_build().validate()
@@ -350,7 +350,7 @@ class LimitedParallel(StateRetryCatch):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		return self._lp_build().to_json()
 
@@ -372,7 +372,7 @@ class LimitedParallel(StateRetryCatch):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = LimitedParallel(
@@ -399,6 +399,6 @@ class LimitedParallel(StateRetryCatch):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		return c

--- a/awssl/ext/parallel_with_finally.py
+++ b/awssl/ext/parallel_with_finally.py
@@ -35,12 +35,12 @@ class ParallelWithFinally(StateRetryCatchFinally):
 	:type: CatcherList: list of ``Catcher``
 	:param FinallyState: [Optional] First state of the finally branch to be invoked
 	:type: FinallyState: Derived from ``StateBase``
-	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 	:type: BranchList: list of ``StateBase``
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None,
 					ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None, BranchList=None):
 		"""
 		Initializer for the ParallelWithFinally state.
@@ -72,12 +72,12 @@ class ParallelWithFinally(StateRetryCatchFinally):
 		:type: CatcherList: list of ``Catcher``
 		:param FinallyState: [Optional] First state of the finally branch to be invoked
 		:type: FinallyState: Derived from ``StateBase``
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 		:type: BranchList: list of ``StateBase``
 
 		"""
-		super(ParallelWithFinally, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(ParallelWithFinally, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, FinallyState=FinallyState)
 		self._branches = None
 		self.set_branch_list(BranchList)
@@ -118,9 +118,9 @@ class ParallelWithFinally(StateRetryCatchFinally):
 
 		At least one branch is required for the state to be valid.
 
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
-		:type: BranchList: list of ``StateBase``		
-		"""		
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
+		:type: BranchList: list of ``StateBase``
+		"""
 		if not BranchList:
 			self._branches = None
 			return
@@ -134,7 +134,7 @@ class ParallelWithFinally(StateRetryCatchFinally):
 				raise Exception("BranchList must contain only subclasses of StateBase (step '{}'".format(self.get_name()))
 		self._branches = []
 		for o in BranchList:
-			self.add_branch(o)				
+			self.add_branch(o)
 
 	def clone(self, NameFormatString="{}"):
 		"""
@@ -150,7 +150,7 @@ class ParallelWithFinally(StateRetryCatchFinally):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = ParallelWithFinally(
@@ -171,9 +171,9 @@ class ParallelWithFinally(StateRetryCatchFinally):
 			c.set_branch_list(BranchList=[ b.get_start_state().clone(NameFormatString) for b in self._branches ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))
 
 		if self.get_finally_state():
-			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))			
+			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))
 
 		return c

--- a/awssl/ext/task_with_finally.py
+++ b/awssl/ext/task_with_finally.py
@@ -8,7 +8,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 	as supporting Timeout for processing as one of those error types.
 
 	As its name suggests, ``TaskWithFinally`` also optionally allows an additional branch to be executed after a successful completion of the task,
-	or if any of the ``Catcher`` s are triggered by an error.  
+	or if any of the ``Catcher`` s are triggered by an error.
 
 	Note that the finally branch will not be executed if no ``Catcher`` traps the error, so it is recommended that a ``Catcher`` is
 	provided that traps ``States.ALL`` if the finally branch must always be executed.
@@ -47,7 +47,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None,
 					ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None,
 					ResourceArn=None, TimeoutSeconds=99999999, HeartbeatSeconds=99999999):
 		"""
@@ -81,8 +81,8 @@ class TaskWithFinally(StateRetryCatchFinally):
 		:type: HeartbeatSeconds: int
 
 		"""
-		super(TaskWithFinally, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(TaskWithFinally, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, FinallyState=FinallyState)
 		self._resource_arn = None
 		self._timeout_seconds = None
@@ -112,11 +112,11 @@ class TaskWithFinally(StateRetryCatchFinally):
 		Sets the Arn of the Lambda of ``Activity`` to be invoked by this ``TaskWithFinally``.  Cannot be ``None`` and must be a valid Arn formatted string.
 
 		:param ResourceArn: [Required] The Arn for the ``Lambda`` function or ``Activity`` that the ``TaskWithFinally`` should invoke
-		:type: ResourceArn: str		
+		:type: ResourceArn: str
 		"""
 		if not ResourceArn:
 			raise Exception("ResourceArn must be specified for TaskWithFinally state (step '{}')".format(self.get_name()))
-		if not isinstance(ResourceArn, str):
+		if not isinstance(ResourceArn, basestring):
 			raise Exception("ResourceArn must be a string for TaskWithFinally state (step '{}')".format(self.get_name()))
 		self._resource_arn = ResourceArn
 		self._changed()
@@ -187,7 +187,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = TaskWithFinally(
@@ -208,7 +208,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		if self.get_finally_state():
 			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))

--- a/awssl/fail_state.py
+++ b/awssl/fail_state.py
@@ -40,7 +40,7 @@ class Fail(StateBase):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state machine is incorrectly defined.
-		
+
 		"""
 		super(Fail, self).validate()
 
@@ -49,7 +49,7 @@ class Fail(StateBase):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		j = super(Fail, self).to_json()
 		j["Error"] = self.get_error_name()
@@ -72,7 +72,7 @@ class Fail(StateBase):
 		:type ErrorName: str
 
 		"""
-		if not isinstance(ErrorName, str):
+		if not isinstance(ErrorName, basestring):
 			raise Exception("ErrorName must be a valid string")
 		self._error_name = ErrorName
 
@@ -90,9 +90,9 @@ class Fail(StateBase):
 
 		:param ErrorCause: [Optional] More detailed information on the cause of the error
 		:type ErrorCause: str
-		
+
 		"""
-		if not isinstance(ErrorCause, str):
+		if not isinstance(ErrorCause, basestring):
 			raise Exception("ErrorCause must be a valid string")
 		self._error_cause = ErrorCause
 
@@ -110,7 +110,7 @@ class Fail(StateBase):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Fail(
@@ -120,4 +120,3 @@ class Fail(StateBase):
 			ErrorCause=self.get_error_cause())
 
 		return c
-

--- a/awssl/not_choice_rule.py
+++ b/awssl/not_choice_rule.py
@@ -56,16 +56,15 @@ class NotChoiceRule(object):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = NotChoiceRule()
 
 		if self.get_comparison():
-			c.set_comparison(Comparison=self.get_comparison().clone())	
+			c.set_comparison(Comparison=self.get_comparison().clone())
 
 		if self.get_next_state():
 			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))
 
 		return c
-

--- a/awssl/or_choice_rule.py
+++ b/awssl/or_choice_rule.py
@@ -65,7 +65,7 @@ class OrChoiceRule(object):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = OrChoiceRule()

--- a/awssl/parallel_state.py
+++ b/awssl/parallel_state.py
@@ -158,7 +158,7 @@ class Parallel(StateRetryCatch):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Parallel(

--- a/awssl/pass_state.py
+++ b/awssl/pass_state.py
@@ -67,7 +67,7 @@ class Pass(StateResult):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state machine is incorrectly defined.
-		
+
 		"""
 		super(Pass, self).validate()
 
@@ -76,7 +76,7 @@ class Pass(StateResult):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		j = super(Pass, self).to_json()
 		if self._result != None:
@@ -88,7 +88,7 @@ class Pass(StateResult):
 		Returns the JSON result of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		return self._result
 
@@ -98,7 +98,7 @@ class Pass(StateResult):
 
 		:param ResultAsJSON: [Optional] Data to be returned by this state, in JSON format.
 		:type ResultPath: dict
-		
+
 		"""
 		if ResultAsJSON and not isinstance(ResultAsJSON, (dict, list)):
 			raise Exception("ResultAsJSON must be valid JSON specification")
@@ -118,7 +118,7 @@ class Pass(StateResult):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Pass(
@@ -131,6 +131,6 @@ class Pass(StateResult):
 			ResultAsJSON=self.get_result())
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		return c

--- a/awssl/retrier.py
+++ b/awssl/retrier.py
@@ -61,7 +61,7 @@ class Retrier(object):
 		if len(ErrorNameList) == 0:
 			raise Exception("ErrorNameList must be a non-empty list for a Retrier")
 		for o in ErrorNameList:
-			if not isinstance(o, str):
+			if not isinstance(o, basestring):
 				raise Exception("ErrorNameList must only contain strings")
 		self._error_name_list = ErrorNameList
 
@@ -80,8 +80,8 @@ class Retrier(object):
 
 		The interval must be >= 1 second.  Default is 1 second.
 
-		:param IntervalSeconds: [Optional] The interval in seconds before retrying the state.  
-		:type IntervalSeconds: int		
+		:param IntervalSeconds: [Optional] The interval in seconds before retrying the state.
+		:type IntervalSeconds: int
 
 		"""
 		if not IntervalSeconds:
@@ -149,7 +149,7 @@ class Retrier(object):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state machine is incorrectly defined.
-		
+
 		"""
 		if not self.get_error_name_list():
 			raise Exception("Retrier must have an ErrorNameList")
@@ -159,7 +159,7 @@ class Retrier(object):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		return {
 			"ErrorEquals" : self.get_error_name_list(),

--- a/awssl/state_base.py
+++ b/awssl/state_base.py
@@ -9,11 +9,11 @@ class StateBase(object):
 	def __init__(self, Name=None, Type=None, Comment=""):
 		if not Name:
 			raise Exception("Name must be specified")
-		if not isinstance(Name, str):
+		if not isinstance(Name, basestring):
 			raise Exception("Name must be a string value")
 		if not Type:
 			raise Exception("Type must be specified (step '{}'".format(Name))
-		if not isinstance(Type, str):
+		if not isinstance(Type, basestring):
 			raise Exception("Type must be a string value (step '{}'".format(Name))
 		if not Type in ["Pass", "Task", "Choice", "Wait", "Succeed", "Fail", "Parallel", "Ext"]:
 			raise Exception("Type must be one of the allowed types for AWS Step Functions (step '{}'".format(Name))
@@ -43,11 +43,10 @@ class StateBase(object):
 	def set_comment(self, Comment=""):
 		comment = ""
 		if Comment:
-			if not isinstance(Comment, str):
+			if not isinstance(Comment, basestring):
 				raise Exception("Comment must be a string value if specified, for step ({})".format(self.get_name()))
 			comment = Comment
 		self._comment = comment
 
 	def get_child_states(self):
 		return [self]
-

--- a/awssl/state_input_output.py
+++ b/awssl/state_input_output.py
@@ -27,7 +27,7 @@ class StateInputOutput(StateBase):
 		return self._input_path
 
 	def set_input_path(self, InputPath="$"):
-		if InputPath and not isinstance(InputPath, str):
+		if InputPath and not isinstance(InputPath, basestring):
 			raise Exception("InputPath must be either a string value if specified, or None, for step ({})".format(self.get_name()))
 		self._input_path = InputPath
 
@@ -35,6 +35,6 @@ class StateInputOutput(StateBase):
 		return self._output_path
 
 	def set_output_path(self, OutputPath="$"):
-		if OutputPath and not isinstance(OutputPath, str):
+		if OutputPath and not isinstance(OutputPath, basestring):
 			raise Exception("OutputPath must be either a string value if specified, or None, for step ({})".format(self.get_name()))
 		self._output_path = OutputPath

--- a/awssl/state_result.py
+++ b/awssl/state_result.py
@@ -24,6 +24,6 @@ class StateResult(StateNextEnd):
 		return self._result_path
 
 	def set_result_path(self, ResultPath="$"):
-		if ResultPath and not isinstance(ResultPath, str):
+		if ResultPath and not isinstance(ResultPath, basestring):
 			raise Exception("ResultPath must be either a string value if specified, or None, for step ({})".format(self.get_name()))
 		self._result_path = ResultPath

--- a/awssl/succeed_state.py
+++ b/awssl/succeed_state.py
@@ -1,7 +1,7 @@
 from .state_input_output import StateInputOutput
 
 class Succeed(StateInputOutput):
-	""" 
+	"""
 	Succeed is a state that terminates a State Machine successfully.
 
 	Succeed are typically used as part of a Condition state, and can receive Input and return Output.
@@ -18,7 +18,7 @@ class Succeed(StateInputOutput):
 	"""
 
 	def __init__(self, Name="", Comment="", InputPath="$", OutputPath="$"):
-		""" 
+		"""
 		Initialiser for an instance of Succeed.
 
 		:param Name: [Required] The name of the state within the branch of the state machine
@@ -38,7 +38,7 @@ class Succeed(StateInputOutput):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state machine is incorrectly defined.
-		
+
 		"""
 		super(Succeed, self).validate()
 
@@ -47,7 +47,7 @@ class Succeed(StateInputOutput):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		return super(Succeed, self).to_json()
 
@@ -65,7 +65,7 @@ class Succeed(StateInputOutput):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Succeed(

--- a/awssl/task_state.py
+++ b/awssl/task_state.py
@@ -128,7 +128,7 @@ class Task(StateRetryCatch):
 		"""
 		if not ResourceArn:
 			raise Exception("ResourceArn must be specified for Task state (step '{}')".format(self.get_name()))
-		if not isinstance(ResourceArn, str):
+		if not isinstance(ResourceArn, basestring):
 			raise Exception("ResourceArn must be a string for Task state (step '{}')".format(self.get_name()))
 		self._resource_arn = ResourceArn
 
@@ -196,7 +196,7 @@ class Task(StateRetryCatch):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Task(

--- a/awssl/wait_state.py
+++ b/awssl/wait_state.py
@@ -3,7 +3,7 @@ from .state_next_end import StateNextEnd
 import datetime
 
 class Wait(StateNextEnd):
-	""" 
+	"""
 	Wait is a Step Function state that pauses execution of the State Machine for a period of time.
 
 	Waits can be durations defined in seconds, or until a specific time.
@@ -39,9 +39,9 @@ class Wait(StateNextEnd):
 
 	"""
 
-	def __init__(self, Name="", Comment="", InputPath="$", OutputPath="$", EndState=False, NextState=None, 
+	def __init__(self, Name="", Comment="", InputPath="$", OutputPath="$", EndState=False, NextState=None,
 		WaitForSeconds=None, WaitForSecondsPath=None, WaitUntilISO8601Timestamp=None, WaitUntilISO8601TimestampPath=None):
-		""" 
+		"""
 		Initialize for the Wait class
 
 		:param Name: [Required] The name of the state within the branch of the state machine
@@ -100,7 +100,7 @@ class Wait(StateNextEnd):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		super(Wait, self).validate()
 		if len(self._get_assigned_wait()) != 1:
@@ -111,7 +111,7 @@ class Wait(StateNextEnd):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		j = super(Wait, self).to_json()
 		for k, v in self._get_assigned_wait().viewitems():
@@ -128,7 +128,7 @@ class Wait(StateNextEnd):
 
 	def set_wait_seconds(self, WaitForSeconds=1):
 		"""
-		Sets the wait interval in seconds.  
+		Sets the wait interval in seconds.
 
 		The interval must be a positive integer if specifed.  Default value is 1 second.
 
@@ -159,7 +159,7 @@ class Wait(StateNextEnd):
 		:type WaitForSecondsPath: str
 
 		"""
-		if WaitForSecondsPath and not isinstance(WaitForSecondsPath, str):
+		if WaitForSecondsPath and not isinstance(WaitForSecondsPath, basestring):
 			raise Exception("WaitForSecondsPath must be an string value (step '{}')".format(self.get_name()))
 		self._reset_waits()
 		self._wait_seconds_path = WaitForSecondsPath
@@ -180,7 +180,7 @@ class Wait(StateNextEnd):
 		:type WaitUntilISO8601Timestamp: str
 		"""
 		if WaitUntilISO8601Timestamp:
-			if not isinstance(WaitUntilISO8601Timestamp, str):
+			if not isinstance(WaitUntilISO8601Timestamp, basestring):
 				raise Exception("WaitUntilISO8601Timestamp must be an string value (step '{}')".format(self.get_name()))
 			try:
 				dt = datetime.datetime.strptime(WaitUntilISO8601Timestamp, "%Y-%m-%dT%H:%M:%SZ")
@@ -194,7 +194,7 @@ class Wait(StateNextEnd):
 		Returns the JSON Path with which to resolve the wait date/time from the Input data supplied to the state.
 
 		:returns: str
-		"""		
+		"""
 		return self._wait_timestamp_path
 
 	def set_wait_timestamp_path(self, WaitUntilISO8601TimestampPath=None):
@@ -206,7 +206,7 @@ class Wait(StateNextEnd):
 		:param WaitUntilISO8601TimestampPath: [Optional] A JSONPath to a datetime string that conforms to the RFC3339 profile of ISO 8601, within the Input data provided to the state.
 		:type WaitUntilISO8601Timestamp: str
 		"""
-		if WaitUntilISO8601TimestampPath and not isinstance(WaitUntilISO8601TimestampPath, str):
+		if WaitUntilISO8601TimestampPath and not isinstance(WaitUntilISO8601TimestampPath, basestring):
 			raise Exception("WaitUntilISO8601TimestampPath must be an string value (step '{}')".format(self.get_name()))
 		self._reset_waits()
 		self._wait_timestamp_path = WaitUntilISO8601TimestampPath
@@ -225,7 +225,7 @@ class Wait(StateNextEnd):
 		"""
 		if not NameFormatString:
 			raise Exception("NameFormatString must not be None (step '{}')".format(self.get_name()))
-		if not isinstance(NameFormatString, str):
+		if not isinstance(NameFormatString, basestring):
 			raise Exception("NameFormatString must be a str (step '{}')".format(self.get_name()))
 
 		c = Wait(
@@ -240,7 +240,6 @@ class Wait(StateNextEnd):
 			WaitUntilISO8601TimestampPath=self.get_wait_timestamp_path())
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))
 
 		return c
-


### PR DESCRIPTION
awssl claims to be Python 2.7 compatible (see https://github.com/slai/awssl#awssl). In Python 2, there are two string types, `str` (sequence of bytes) and `unicode` (sequence of unicode code points). Both of these inherit from the abstract `basestring` type.

Therefore when checking types, the `basestring` type should be used instead of `str`.

For Python 3 compatibility (there's only `str`), six can be used (https://pythonhosted.org/six/#six.string_types).

It would be a lot easier to review this PR by setting the 'hide whitespace changes' option in GitHub. If this is a problem I can try and remove the whitespace changes.