### PR TITLE
EndState must be a bool, not None

### DIFF
--- a/awssl/ext/branch_retry_parallel.py
+++ b/awssl/ext/branch_retry_parallel.py
@@ -1,4 +1,4 @@
-from ..pass_state import Pass 
+from ..pass_state import Pass
 from ..parallel_state import Parallel
 from .parallel_with_finally import ParallelWithFinally
 from ..state_base import StateBase
@@ -35,17 +35,17 @@ class BranchRetryParallel(ParallelWithFinally):
 	:type: CatcherList: list of ``Catcher``
 	:param FinallyState: [Optional] First state of the finally branch to be invoked
 	:type: FinallyState: Derived from ``StateBase``
-	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 	:type: BranchList: list of ``StateBase``
 	:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that can be retried for each branch
 	:type: BranchRetryList: list of ``StateBase``
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
 					ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None, BranchList=None, BranchRetryList=None):
-		super(BranchRetryParallel, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(BranchRetryParallel, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, FinallyState=FinallyState)
 		"""
 		Initializer for the ``BranchRetryParallel`` state.
@@ -75,7 +75,7 @@ class BranchRetryParallel(ParallelWithFinally):
 		:type: CatcherList: list of ``Catcher``
 		:param FinallyState: [Optional] First state of the finally branch to be invoked
 		:type: FinallyState: Derived from ``StateBase``
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 		:type: BranchList: list of ``StateBase``
 		:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that can be retried for each branch
 		:type: BranchRetryList: list of ``StateBase``
@@ -89,7 +89,7 @@ class BranchRetryParallel(ParallelWithFinally):
 	def _get_underlying_state_no_retry_catch(self, state_name):
 		branch_list = []
 		if self.get_branch_retry_list() and len(self.get_branch_retry_list()) > 0:
-			# Wrap each branch in its own retrying Parallel		
+			# Wrap each branch in its own retrying Parallel
 			for b in self.get_branch_list():
 				final_state = Pass(
 					Name="{}-Finalizer-{}".format(self.get_name(), b.get_name()),
@@ -129,8 +129,8 @@ class BranchRetryParallel(ParallelWithFinally):
 
 		At least one branch is required for the state to be valid.
 
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
-		:type: BranchList: list of ``StateBase``		
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
+		:type: BranchList: list of ``StateBase``
 		"""
 		if not BranchList:
 			self._brp_branch_list = None
@@ -149,7 +149,7 @@ class BranchRetryParallel(ParallelWithFinally):
 
 	def get_branch_retry_list(self):
 		"""
-		Returns the list of ``Retrier`` instances that will be applied to each branch separately, allowing failure 
+		Returns the list of ``Retrier`` instances that will be applied to each branch separately, allowing failure
 		in one branch to be retried without having to re-execute all the branches of the ``Parallel``.
 
 		:returns: ``list`` of ``Retrier`` instances
@@ -213,7 +213,7 @@ class BranchRetryParallel(ParallelWithFinally):
 			c.set_branch_retry_list(BranchRetryList=[ r.clone() for r in self.get_branch_retry_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		if self.get_finally_state():
 			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))

--- a/awssl/ext/for_state.py
+++ b/awssl/ext/for_state.py
@@ -1,5 +1,5 @@
-from ..pass_state import Pass 
-from ..task_state import Task 
+from ..pass_state import Pass
+from ..task_state import Task
 from ..parallel_state import Parallel
 from ..state_base import StateBase
 from ..retrier import Retrier
@@ -13,7 +13,7 @@ _FINALIZER = "ForFinalizer"
 _FINALIZER_PARALLEL_ITERATION = "ForFinalizerParallelIterations"
 _LIMITED_PARALLEL_CONSOLIDATOR = "LimitedParallelConsolidator"
 
-def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None, 
+def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None,
 				ForFinalizer=None, ForFinalizerParallelIterations=None,
 				LimitedParallelConsolidator=None):
 	"""
@@ -22,7 +22,7 @@ def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None,
 	The functions are available in the github repo both as individual lambdas or combined in a CloudFormation script for easy deployment.
 
 	All the Arns must be specified or this function will generate an Exception.
-	
+
 	:param ForInitializer: The Arn of the ForInitializer Lambda function, used by the ``For`` state
 	:type ForInitializer: str
 	:param ForExtractor: The Arn of the ForExtractor Lambda function, used by the ``For`` state
@@ -44,8 +44,8 @@ def set_ext_arns(ForInitializer=None, ForExtractor=None, ForConsolidator=None,
 			raise Exception("set_ext_arns: {} must be a str".format(val_name))
 		_ext_arns[val_name] = val
 
-	for v, n in [(ForInitializer, _INITIALIZER), (ForExtractor, _EXTRACTOR), 
-				(ForConsolidator, _CONSOLIDATOR), (ForFinalizer, _FINALIZER), 
+	for v, n in [(ForInitializer, _INITIALIZER), (ForExtractor, _EXTRACTOR),
+				(ForConsolidator, _CONSOLIDATOR), (ForFinalizer, _FINALIZER),
 				(ForFinalizerParallelIterations, _FINALIZER_PARALLEL_ITERATION),
 				(LimitedParallelConsolidator, _LIMITED_PARALLEL_CONSOLIDATOR) ]:
 		apply_arg(v, n)
@@ -122,8 +122,8 @@ class For(Parallel):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
-					ResultPath="$", RetryList=None, CatcherList=None, BranchState=None, BranchRetryList=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
+					ResultPath="$", RetryList=None, CatcherList=None, BranchState=None, BranchRetryList=None,
 					From=0, To=0, Step=1, IteratorPath="$.iteration", ParallelIteration=False):
 		"""
 		Initializer for the ``For`` class
@@ -161,12 +161,12 @@ class For(Parallel):
 		:param ParallelIteration: [Optional] Whether the ``For`` branches can be run concurrently or must be executed sequentially.  Default is sequential.
 		:type ParallelIteration: bool
 
-		"""		
-		super(For, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		"""
+		super(For, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, BranchList=None)
 		self._branch_state = None
-		self._from = 0 
+		self._from = 0
 		self._to = 0
 		self._step = 1
 		self._iterator_path = None
@@ -288,8 +288,8 @@ class For(Parallel):
 		"""
 		Sets the starting value for the ``For`` loop.  Must be an integer or float.  Default value is zero.
 
-		:param From: [Required] The starting value of the iteration.  
-		:type From: int or float		
+		:param From: [Required] The starting value of the iteration.
+		:type From: int or float
 		"""
 		if not isinstance(From, (int, float)):
 			raise Exception("From must be either an int or a float (step '{}')".format(self.get_name()))
@@ -307,8 +307,8 @@ class For(Parallel):
 		"""
 		Sets the ending value for the ``For`` loop.  Must be an integer or float.  Default value is zero.
 
-		:param To: [Required] The ending value of the iteration.  
-		:type To: int or float		
+		:param To: [Required] The ending value of the iteration.
+		:type To: int or float
 		"""
 		if not isinstance(To, (int, float)):
 			raise Exception("To must be either an int or a float (step '{}')".format(self.get_name()))
@@ -326,8 +326,8 @@ class For(Parallel):
 		"""
 		Sets the increment value for the ``For`` loop.  Must be an integer or float.  Default value is 1.
 
-		:param Step: [Required] The increment value of the iteration.  
-		:type Step: int or float		
+		:param Step: [Required] The increment value of the iteration.
+		:type Step: int or float
 		"""
 		if not isinstance(Step, (int, float)):
 			raise Exception("Step must be either an int or a float (step '{}')".format(self.get_name()))
@@ -357,7 +357,7 @@ class For(Parallel):
 
 	def get_branch_retry_list(self):
 		"""
-		Returns the list of ``Retrier`` instances that will be applied separately to each ``For`` branch iteration, allowing failure 
+		Returns the list of ``Retrier`` instances that will be applied separately to each ``For`` branch iteration, allowing failure
 		in one branch iteration during the ``For`` loop to be retried without having to re-execute all the branches of the ``For``.
 
 		:returns: ``list`` of ``Retrier`` instances
@@ -416,7 +416,7 @@ class For(Parallel):
 		"""
 		Specifies whether the execution of the ``For`` loop can be performed concurrently, or must be sequential.  Default is sequential.
 
-		:param ParallelIteration: [Optional] Whether the ``For`` branches can be run concurrently or must be executed sequentially.  
+		:param ParallelIteration: [Optional] Whether the ``For`` branches can be run concurrently or must be executed sequentially.
 		:type ParallelIteration: bool
 		"""
 		self._parallel_iteration = ParallelIteration
@@ -426,7 +426,7 @@ class For(Parallel):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		self._build_for_loop()
 		super(For, self).validate()
@@ -436,7 +436,7 @@ class For(Parallel):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		self._build_for_loop()
 		return super(For, self).to_json()
@@ -481,6 +481,6 @@ class For(Parallel):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		return c

--- a/awssl/ext/limited_parallel_state.py
+++ b/awssl/ext/limited_parallel_state.py
@@ -1,5 +1,5 @@
-from ..pass_state import Pass 
-from ..task_state import Task 
+from ..pass_state import Pass
+from ..task_state import Task
 from ..parallel_state import Parallel
 from ..retrier import Retrier
 from ..state_base import StateBase
@@ -43,7 +43,7 @@ class LimitedParallel(StateRetryCatch):
 	:type: RetryList: list of ``Retrier``
 	:param CatcherList: [Optional] ``list`` of ``Catcher`` instances corresponding to error states that can be caught and handled by further states being executed in the ``StateMachine``.
 	:type: CatcherList: list of ``Catcher``
-	:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently 
+	:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently
 	:type: BranchState: ``StateBase``
 	:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that cause the ``For`` loop iteration to be retried.  This will occur until the number of retries has been exhausted for this iteration, afterwhich state level ``Retrier`` will be triggered if specified
 	:type BranchRetryList: list of ``Retrier``
@@ -56,8 +56,8 @@ class LimitedParallel(StateRetryCatch):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
-					ResultPath="$", RetryList=None, CatcherList=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
+					ResultPath="$", RetryList=None, CatcherList=None,
 					BranchState=None, BranchRetryList=None,
 					Iterations=0, MaxConcurrency=1, IteratorPath="$.iteration"):
 		"""
@@ -81,7 +81,7 @@ class LimitedParallel(StateRetryCatch):
 		:type: RetryList: list of ``Retrier``
 		:param CatcherList: [Optional] ``list`` of ``Catcher`` instances corresponding to error states that can be caught and handled by further states being executed in the ``StateMachine``.
 		:type: CatcherList: list of ``Catcher``
-		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently 
+		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently
 		:type: BranchState: ``StateBase``
 		:param BranchRetryList: [Optional] ``list`` of ``Retrier`` instances corresponding to error states that cause the ``For`` loop iteration to be retried.  This will occur until the number of retries has been exhausted for this iteration, afterwhich state level ``Retrier`` will be triggered if specified
 		:type BranchRetryList: list of ``Retrier``
@@ -93,8 +93,8 @@ class LimitedParallel(StateRetryCatch):
 		:type: IteratorPath: str
 
 		"""
-		super(LimitedParallel, self).__init__(Name=Name, Type="Ext", Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(LimitedParallel, self).__init__(Name=Name, Type="Ext", Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList)
 		self._branch_state = None
 		self._max_concurrent = 1
@@ -116,23 +116,23 @@ class LimitedParallel(StateRetryCatch):
 
 			for_state = For(Name="{}-For-{}".format(state_name, cycle),
 							EndState=True,
-							From=iteration_offset, 
-							To=iteration_offset+iterations, 
-							Step=1, 
+							From=iteration_offset,
+							To=iteration_offset+iterations,
+							Step=1,
 							BranchState=branch_state,
 							BranchRetryList=branch_retry_list,
-							IteratorPath=iterator_path, 
+							IteratorPath=iterator_path,
 							ParallelIteration=True)
 
-			inputs = Pass(Name="{}-Pass-Inputs-{}".format(state_name, cycle), 
+			inputs = Pass(Name="{}-Pass-Inputs-{}".format(state_name, cycle),
 				OutputPath="$.[0]",
 				EndState=True)
 
-			existing_results = Pass(Name="{}-Pass-Results-{}".format(state_name, cycle), 
+			existing_results = Pass(Name="{}-Pass-Results-{}".format(state_name, cycle),
 				OutputPath="$.[1]",
 				EndState=True)
 
-			loop_inputs = Pass(Name="{}-Loop-Inputs-{}".format(state_name, cycle), 
+			loop_inputs = Pass(Name="{}-Loop-Inputs-{}".format(state_name, cycle),
 				OutputPath="$.[0]",
 				EndState=False,
 				NextState=for_state)
@@ -143,7 +143,7 @@ class LimitedParallel(StateRetryCatch):
 			if cycle == 0:
 				initializer_arn = get_ext_arn(_INITIALIZER)
 
-			cycle_state = Parallel(Name="{}-Parallel-{}".format(state_name, cycle), 
+			cycle_state = Parallel(Name="{}-Parallel-{}".format(state_name, cycle),
 									EndState=True,
 									BranchList=branch_list)
 
@@ -169,7 +169,7 @@ class LimitedParallel(StateRetryCatch):
 				cycle_iterations = self.get_max_concurrency()
 			remaining_iterations = remaining_iterations - cycle_iterations
 
-			cycle_initializer, prior_state = create_states_for_cycle(cycle, cycle_iterations, cycle * self.get_max_concurrency(), 
+			cycle_initializer, prior_state = create_states_for_cycle(cycle, cycle_iterations, cycle * self.get_max_concurrency(),
 												self.get_branch_state(), self.get_branch_retry_list(),
 												self.get_iterator_path(), prior_state, self.get_name())
 
@@ -225,7 +225,7 @@ class LimitedParallel(StateRetryCatch):
 		"""
 		Set the initial state for the branch processing
 
-		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently 
+		:param BranchState: [Required] ``StateBase`` instance, providing the starting state for each branch to be run concurrently
 		:type: BranchState: ``StateBase``
 		"""
 		if BranchState and not isinstance(BranchState, StateBase):
@@ -234,7 +234,7 @@ class LimitedParallel(StateRetryCatch):
 
 	def get_branch_retry_list(self):
 		"""
-		Returns the list of ``Retrier`` instances that will be applied separately to each branch execution, allowing failure 
+		Returns the list of ``Retrier`` instances that will be applied separately to each branch execution, allowing failure
 		in one branch iteration during the ``LimitedParallel`` execution to be retried.
 
 		:returns: ``list`` of ``Retrier`` instances
@@ -337,10 +337,10 @@ class LimitedParallel(StateRetryCatch):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		# Ensure basic inputs are ok
-		super(LimitedParallel, self).validate() 
+		super(LimitedParallel, self).validate()
 
 		# Ensure constructed LimitedParallel is ok
 		self._lp_build().validate()
@@ -350,7 +350,7 @@ class LimitedParallel(StateRetryCatch):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		return self._lp_build().to_json()
 
@@ -399,6 +399,6 @@ class LimitedParallel(StateRetryCatch):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		return c

--- a/awssl/ext/parallel_with_finally.py
+++ b/awssl/ext/parallel_with_finally.py
@@ -35,12 +35,12 @@ class ParallelWithFinally(StateRetryCatchFinally):
 	:type: CatcherList: list of ``Catcher``
 	:param FinallyState: [Optional] First state of the finally branch to be invoked
 	:type: FinallyState: Derived from ``StateBase``
-	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 	:type: BranchList: list of ``StateBase``
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
 					ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None, BranchList=None):
 		"""
 		Initializer for the ParallelWithFinally state.
@@ -72,12 +72,12 @@ class ParallelWithFinally(StateRetryCatchFinally):
 		:type: CatcherList: list of ``Catcher``
 		:param FinallyState: [Optional] First state of the finally branch to be invoked
 		:type: FinallyState: Derived from ``StateBase``
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 		:type: BranchList: list of ``StateBase``
 
 		"""
-		super(ParallelWithFinally, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(ParallelWithFinally, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, FinallyState=FinallyState)
 		self._branches = None
 		self.set_branch_list(BranchList)
@@ -118,9 +118,9 @@ class ParallelWithFinally(StateRetryCatchFinally):
 
 		At least one branch is required for the state to be valid.
 
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
-		:type: BranchList: list of ``StateBase``		
-		"""		
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
+		:type: BranchList: list of ``StateBase``
+		"""
 		if not BranchList:
 			self._branches = None
 			return
@@ -134,7 +134,7 @@ class ParallelWithFinally(StateRetryCatchFinally):
 				raise Exception("BranchList must contain only subclasses of StateBase (step '{}'".format(self.get_name()))
 		self._branches = []
 		for o in BranchList:
-			self.add_branch(o)				
+			self.add_branch(o)
 
 	def clone(self, NameFormatString="{}"):
 		"""
@@ -171,9 +171,9 @@ class ParallelWithFinally(StateRetryCatchFinally):
 			c.set_branch_list(BranchList=[ b.get_start_state().clone(NameFormatString) for b in self._branches ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))
 
 		if self.get_finally_state():
-			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))			
+			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))
 
 		return c

--- a/awssl/ext/state_retry_catch_finally.py
+++ b/awssl/ext/state_retry_catch_finally.py
@@ -12,9 +12,9 @@ class StateRetryCatchFinally(StateRetryCatch):
 		TaskWithFinally, ParallelWithFinally
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None):
-		super(StateRetryCatchFinally, self).__init__(Name=Name, Type="Ext", Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False, ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None):
+		super(StateRetryCatchFinally, self).__init__(Name=Name, Type="Ext", Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList)
 		self._finally_branch = None
 		self._constructed_states = None
@@ -145,4 +145,3 @@ class StateRetryCatchFinally(StateRetryCatch):
 			if not isinstance(FinallyState, StateBase):
 				raise Exception("FinallyState must inherited from StateBase, for step ({})".format(self.get_name()))
 		self._finally_branch = FinallyState
-

--- a/awssl/ext/task_with_finally.py
+++ b/awssl/ext/task_with_finally.py
@@ -8,7 +8,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 	as supporting Timeout for processing as one of those error types.
 
 	As its name suggests, ``TaskWithFinally`` also optionally allows an additional branch to be executed after a successful completion of the task,
-	or if any of the ``Catcher`` s are triggered by an error.  
+	or if any of the ``Catcher`` s are triggered by an error.
 
 	Note that the finally branch will not be executed if no ``Catcher`` traps the error, so it is recommended that a ``Catcher`` is
 	provided that traps ``States.ALL`` if the finally branch must always be executed.
@@ -47,7 +47,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
 					ResultPath="$", RetryList=None, CatcherList=None, FinallyState=None,
 					ResourceArn=None, TimeoutSeconds=99999999, HeartbeatSeconds=99999999):
 		"""
@@ -81,8 +81,8 @@ class TaskWithFinally(StateRetryCatchFinally):
 		:type: HeartbeatSeconds: int
 
 		"""
-		super(TaskWithFinally, self).__init__(Name=Name, Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(TaskWithFinally, self).__init__(Name=Name, Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList, FinallyState=FinallyState)
 		self._resource_arn = None
 		self._timeout_seconds = None
@@ -112,7 +112,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 		Sets the Arn of the Lambda of ``Activity`` to be invoked by this ``TaskWithFinally``.  Cannot be ``None`` and must be a valid Arn formatted string.
 
 		:param ResourceArn: [Required] The Arn for the ``Lambda`` function or ``Activity`` that the ``TaskWithFinally`` should invoke
-		:type: ResourceArn: str		
+		:type: ResourceArn: str
 		"""
 		if not ResourceArn:
 			raise Exception("ResourceArn must be specified for TaskWithFinally state (step '{}')".format(self.get_name()))
@@ -208,7 +208,7 @@ class TaskWithFinally(StateRetryCatchFinally):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		if self.get_finally_state():
 			c.set_finally_state(FinallyState=self.get_finally_state().clone(NameFormatString))

--- a/awssl/parallel_state.py
+++ b/awssl/parallel_state.py
@@ -31,12 +31,12 @@ class Parallel(StateRetryCatch):
 	:type: RetryList: list of ``Retrier``
 	:param CatcherList: [Optional] ``list`` of ``Catcher`` instances corresponding to error states that can be caught and handled by further states being executed in the ``StateMachine``.
 	:type: CatcherList: list of ``Catcher``
-	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+	:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 	:type: BranchList: list of ``StateBase``
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
 					ResultPath="$", RetryList=None, CatcherList=None, BranchList=None):
 		"""
 		Initializer for the Parallel state.
@@ -66,12 +66,12 @@ class Parallel(StateRetryCatch):
 		:type: RetryList: list of ``Retrier``
 		:param CatcherList: [Optional] ``list`` of ``Catcher`` instances corresponding to error states that can be caught and handled by further states being executed in the ``StateMachine``.
 		:type: CatcherList: list of ``Catcher``
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
 		:type: BranchList: list of ``StateBase``
 
 		"""
-		super(Parallel, self).__init__(Name=Name, Type="Parallel", Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(Parallel, self).__init__(Name=Name, Type="Parallel", Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList)
 		self._branches = None
 		self.set_branch_list(BranchList)
@@ -94,8 +94,8 @@ class Parallel(StateRetryCatch):
 
 		At least one branch is required for the state to be valid.
 
-		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently 
-		:type: BranchList: list of ``StateBase``		
+		:param BranchList: [Required] ``list`` of ``StateBase`` instances, providing the starting states for each branch to be run concurrently
+		:type: BranchList: list of ``StateBase``
 		"""
 		if not BranchList:
 			self._branches = None
@@ -110,18 +110,18 @@ class Parallel(StateRetryCatch):
 				raise Exception("BranchList must contain only subclasses of StateBase (step '{}'".format(self.get_name()))
 		self._branches = []
 		for o in BranchList:
-			self.add_branch(o)				
+			self.add_branch(o)
 
 	def validate(self):
 		"""
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		super(Parallel, self).validate()
 
-		if (not self._branches) or len(self._branches) == 0: 
+		if (not self._branches) or len(self._branches) == 0:
 			raise Exception("Parallel state must contain at least one branch (step '{}'".format(self.get_name()))
 		for b in self._branches:
 			b.validate()
@@ -131,9 +131,9 @@ class Parallel(StateRetryCatch):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
-		if (not self._branches) or len(self._branches) == 0: 
+		if (not self._branches) or len(self._branches) == 0:
 			raise Exception("Parallel state must contain at least one branch (step '{}'".format(self.get_name()))
 
 		branches = []
@@ -179,6 +179,6 @@ class Parallel(StateRetryCatch):
 			c.set_branch_list(BranchList=[ b.get_start_state().clone(NameFormatString) for b in self._branches ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state().clone(NameFormatString))
 
 		return c

--- a/awssl/state_result.py
+++ b/awssl/state_result.py
@@ -7,7 +7,7 @@ class StateResult(StateNextEnd):
 		Pass, Task, Parallel
 	"""
 
-	def __init__(self, Name=None, Type=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, ResultPath="$"):
+	def __init__(self, Name=None, Type=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False, ResultPath="$"):
 		super(StateResult, self).__init__(Name=Name, Type=Type, Comment=Comment, InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState)
 		self._result_path = "$"
 		self.set_result_path(ResultPath)

--- a/awssl/state_retry_catch.py
+++ b/awssl/state_retry_catch.py
@@ -9,8 +9,8 @@ class StateRetryCatch(StateResult):
 		Task, Parallel
 	"""
 
-	def __init__(self, Name=None, Type=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, ResultPath="$", RetryList=None, CatcherList=None):
-		super(StateRetryCatch, self).__init__(Name=Name, Type=Type, Comment=Comment, 
+	def __init__(self, Name=None, Type=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False, ResultPath="$", RetryList=None, CatcherList=None):
+		super(StateRetryCatch, self).__init__(Name=Name, Type=Type, Comment=Comment,
 			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, ResultPath=ResultPath)
 		self._retry_list = None
 		self._catcher_list = None

--- a/awssl/task_state.py
+++ b/awssl/task_state.py
@@ -40,7 +40,7 @@ class Task(StateRetryCatch):
 
 	"""
 
-	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=None, 
+	def __init__(self, Name=None, Comment="", InputPath="$", OutputPath="$", NextState=None, EndState=False,
 					ResultPath="$", RetryList=None, CatcherList=None,
 					ResourceArn=None, TimeoutSeconds=99999999, HeartbeatSeconds=99999999):
 		"""
@@ -77,8 +77,8 @@ class Task(StateRetryCatch):
 		:type: HeartbeatSeconds: int
 
 		"""
-		super(Task, self).__init__(Name=Name, Type="Task", Comment=Comment, 
-			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState, 
+		super(Task, self).__init__(Name=Name, Type="Task", Comment=Comment,
+			InputPath=InputPath, OutputPath=OutputPath, NextState=NextState, EndState=EndState,
 			ResultPath=ResultPath, RetryList=RetryList, CatcherList=CatcherList)
 		self._resource_arn = None
 		self._timeout_seconds = None
@@ -92,7 +92,7 @@ class Task(StateRetryCatch):
 		Validates this instance is correctly specified.
 
 		Raises ``Exception`` with details of the error, if the state is incorrectly defined.
-		
+
 		"""
 		super(Task, self).validate()
 
@@ -101,7 +101,7 @@ class Task(StateRetryCatch):
 		Returns the JSON representation of this instance.
 
 		:returns: dict -- The JSON representation
-		
+
 		"""
 		j = super(Task, self).to_json()
 		j["Resource"] = self.get_resource_arn()
@@ -124,7 +124,7 @@ class Task(StateRetryCatch):
 		Sets the Arn of the Lambda of ``Activity`` to be invoked by this ``Task``.  Cannot be ``None`` and must be a valid Arn formatted string.
 
 		:param ResourceArn: [Required] The Arn for the ``Lambda`` function or ``Activity`` that the ``Task`` should invoke
-		:type: ResourceArn: str		
+		:type: ResourceArn: str
 		"""
 		if not ResourceArn:
 			raise Exception("ResourceArn must be specified for Task state (step '{}')".format(self.get_name()))
@@ -217,6 +217,6 @@ class Task(StateRetryCatch):
 			c.set_catcher_list(CatcherList=[ c.clone(NameFormatString) for c in self.get_catcher_list() ])
 
 		if self.get_next_state():
-			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))	
+			c.set_next_state(NextState=self.get_next_state.clone(NameFormatString))
 
 		return c


### PR DESCRIPTION
In class `StateNextEnd`, the `EndState` value is checked to ensure it is a boolean. In the subclasses however, the default value for `EndState` is `None`, which means if `EndState` is not specified, it would fail as the default value of `None` is not an instance of the bool type.

This PR changes the subclass `__init__` methods so the default value for `EndState` is `False` instead. This matches up with the doc string.

Again, the PR is best viewed with `hide whitespace changes` enabled.